### PR TITLE
Make REDIS_PASSWORD required

### DIFF
--- a/compose/.env-release
+++ b/compose/.env-release
@@ -16,6 +16,9 @@ SEATABLE_ADMIN_PASSWORD=
 # database
 MARIADB_PASSWORD=
 
+# redis
+REDIS_PASSWORD=
+
 # shared secret for secure communication
 JWT_PRIVATE_KEY=
 

--- a/compose/migrate/migrate_5.2_5.3.sh
+++ b/compose/migrate/migrate_5.2_5.3.sh
@@ -53,6 +53,11 @@ sed -i '/^DATABASES = {/,/^}/d' "${CONFIG_DIRECTORY}/dtable_web_settings.py"
 echo "Removing CACHES from dtable_web_settings.py"
 sed -i '/^CACHES = {/,/^}/d' "${CONFIG_DIRECTORY}/dtable_web_settings.py"
 
+echo "Generating REDIS_PASSWORD using pwgen"
+REDIS_PASSWORD=$(pwgen 32 1)
+echo "Adding REDIS_PASSWORD to /opt/seatable-compose/.env"
+echo "REDIS_PASSWORD=${REDIS_PASSWORD}" >> /opt/seatable-compose/.env
+
 echo "Done!"
 echo "Please verify your configuration files."
 echo "You can use \"diff --unified --color ${BACKUP_DIRECTORY} ${CONFIG_DIRECTORY}\" to compare both directories."

--- a/compose/seatable-server.yml
+++ b/compose/seatable-server.yml
@@ -22,7 +22,7 @@ services:
       - SEATABLE_MYSQL_DB_SEAFILE_DB_NAME=seafile_db
       - REDIS_HOST=${REDIS_HOST:-redis}
       - REDIS_PORT=${REDIS_PORT:-6379}
-      - REDIS_PASSWORD=${REDIS_PASSWORD:-}
+      - REDIS_PASSWORD=${REDIS_PASSWORD:?Variable is not set or empty}
       - JWT_PRIVATE_KEY=${JWT_PRIVATE_KEY:?Variable is not set or empty}
       - ENABLE_SEADOC=${ENABLE_SEADOC:-false}
       - SEADOC_SERVER_URL=${SEATABLE_SERVER_PROTOCOL:-}://${SEATABLE_SERVER_HOSTNAME:-}:${SEADOC_PORT:-}
@@ -150,6 +150,12 @@ services:
     image: ${SEATABLE_REDIS_IMAGE:-redis:7.2.7-bookworm}
     restart: unless-stopped
     container_name: redis
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD:?Variable is not set or empty}
+    command:
+      - /bin/sh
+      - -c
+      - redis-server --requirepass "$${REDIS_PASSWORD:?REDIS_PASSWORD variable is not set}"
     networks:
       - backend-seatable-net
     healthcheck:


### PR DESCRIPTION
Works on 5.3.7

To Do:

- [x] Update migration script
- [x] Update seatable-admin-docs installation guide -> https://github.com/seatable/seatable-admin-docs/pull/259