### PR TITLE
Upgrade mariadb + redis

### DIFF
--- a/compose/python-pipeline-standalone.yml
+++ b/compose/python-pipeline-standalone.yml
@@ -1,7 +1,7 @@
 ---
 services:
   mariadb:
-    image: ${SEATABLE_DB_IMAGE:-mariadb:11.4.3-noble}
+    image: ${SEATABLE_DB_IMAGE:-mariadb:11.8.5-noble}
     restart: unless-stopped
     container_name: mariadb
     environment:

--- a/compose/seatable-server.yml
+++ b/compose/seatable-server.yml
@@ -118,7 +118,7 @@ services:
       timeout: 10s
 
   mariadb:
-    image: ${SEATABLE_DB_IMAGE:-mariadb:11.8.3-noble}
+    image: ${SEATABLE_DB_IMAGE:-mariadb:11.8.5-noble}
     restart: unless-stopped
     container_name: mariadb
     command: ["mariadbd", "--innodb_snapshot_isolation=OFF"]
@@ -150,7 +150,7 @@ services:
       # more info at https://admin.seatable.com/upgrade/extra-upgrade-notice/
 
   redis:
-    image: ${SEATABLE_REDIS_IMAGE:-redis:8.2.2-bookworm}
+    image: ${SEATABLE_REDIS_IMAGE:-redis:8.4.0-bookworm}
     restart: unless-stopped
     container_name: redis
     environment:


### PR DESCRIPTION
- MariaDB: 11.8.5 is the latest LTS release
- Redis: 8.4.0 is the latest release