### PR TITLE
Add `seatable-s3.yml`

### DIFF
--- a/compose/seatable-s3.yml
+++ b/compose/seatable-s3.yml
@@ -1,0 +1,17 @@
+services:
+  seatable-server:
+    environment:
+      - STORAGE_TYPE=s3
+      - S3_STORAGE_BUCKET=${S3_STORAGE_BUCKET:?Variable is not set or empty}
+      - S3_COMMIT_BUCKET=${S3_COMMIT_BUCKET:?Variable is not set or empty}
+      - S3_FS_BUCKET=${S3_FS_BUCKET:?Variable is not set or empty}
+      - S3_BLOCK_BUCKET=${S3_BLOCK_BUCKET:?Variable is not set or empty}
+      - S3_KEY_ID=${S3_KEY_ID:?Variable is not set or empty}
+      - S3_SECRET_KEY=${S3_SECRET_KEY:?Variable is not set or empty}
+      - S3_USE_V4_SIGNATURE=${S3_USE_V4_SIGNATURE:-true}
+      - S3_AWS_REGION=${S3_AWS_REGION:-us-east-1}
+      - S3_HOST=${S3_HOST:-}
+      - S3_USE_HTTPS=${S3_USE_HTTPS:-true}
+      - S3_PATH_STYLE_REQUEST=${S3_PATH_STYLE_REQUEST:-false}
+      - S3_SSE_C_KEY=${S3_SSE_C_KEY:-}
+      - S3_PART_SIZE=${S3_PART_SIZE:-}


### PR DESCRIPTION
This file extends the definition of the `seatable-server` service to enable the S3 backend for `dtable-storage-server` and Seafile. 