### PR TITLE
caddy-docker-proxy v2.12.0

### DIFF
--- a/compose/caddy.yml
+++ b/compose/caddy.yml
@@ -3,7 +3,7 @@ services:
   ## Web Server / Reverse Proxy
   # Handles TLS termination using either Let's Encrypt or custom certificates
   caddy:
-    image: ${IMAGE_CADDY:-lucaslorentz/caddy-docker-proxy:2.11.0-alpine}
+    image: ${IMAGE_CADDY:-lucaslorentz/caddy-docker-proxy:2.12.0-alpine}
     restart: unless-stopped
     container_name: caddy
     ports:

--- a/compose/caddy.yml
+++ b/compose/caddy.yml
@@ -3,7 +3,7 @@ services:
   ## Web Server / Reverse Proxy
   # Handles TLS termination using either Let's Encrypt or custom certificates
   caddy:
-    image: ${IMAGE_CADDY:-lucaslorentz/caddy-docker-proxy:2.10.0-alpine}
+    image: ${IMAGE_CADDY:-lucaslorentz/caddy-docker-proxy:2.11.0-alpine}
     restart: unless-stopped
     container_name: caddy
     ports:


### PR DESCRIPTION
Caddy Release Notes: https://github.com/caddyserver/caddy/releases/tag/v2.11.1

This fixes a bunch of CVEs inside Caddy.