### PR TITLE
Set `ENABLE_PYTHON_SCRIPT` to `false` by default

### DIFF
--- a/compose/python-pipeline.yml
+++ b/compose/python-pipeline.yml
@@ -82,6 +82,11 @@ services:
       # Docker-Compose does not seem to create networks that are not used by any containers in the compose file(s)
       - runner-net
 
+  # Override ENABLE_PYTHON_SCRIPT for seatable-server
+  seatable-server:
+    environment:
+      - ENABLE_PYTHON_SCRIPT=true
+
 networks:
   frontend-net:
     name: frontend-net

--- a/compose/seatable-server.yml
+++ b/compose/seatable-server.yml
@@ -29,7 +29,7 @@ services:
       - SEATABLE_ADMIN_EMAIL=${SEATABLE_ADMIN_EMAIL:?Variable is not set or empty}
       - SEATABLE_ADMIN_PASSWORD=${SEATABLE_ADMIN_PASSWORD:?Variable is not set or empty}
       - TIME_ZONE=${TIME_ZONE:?Variable is not set or empty}
-      - ENABLE_PYTHON_SCRIPT=${ENABLE_PYTHON_SCRIPT:-true}
+      - ENABLE_PYTHON_SCRIPT=${ENABLE_PYTHON_SCRIPT:-false}
       - PYTHON_SCHEDULER_URL=${PYTHON_SCHEDULER_URL:-http://python-scheduler}
       - PYTHON_SCHEDULER_AUTH_TOKEN=${PYTHON_SCHEDULER_AUTH_TOKEN:-}
       - REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
This removes the errors in dtable_web.log in case the Python-Pipeline is not configured.

Users of `python-pipeline-standalone.yml` will need to set `ENABLE_PYTHON_SCRIPT` to `true` inside their `.env` file.

I already updated the docs to reflect this change: https://github.com/seatable/seatable-admin-docs/pull/314/changes/0355080a8d60d7a89153a111476b01c0a178b33d