### PR TITLE
Require license file to exist

### DIFF
--- a/compose/seatable-server.yml
+++ b/compose/seatable-server.yml
@@ -11,6 +11,8 @@ services:
         source: "./seatable-license.txt"
         target: "/shared/seatable/seatable-license.txt"
         read_only: ${SEATABLE_LICENSE_FORCE_READ_ONLY:-false}
+        bind:
+          create_host_path: false
     environment:
       - SEATABLE_MYSQL_DB_HOST=${MARIADB_HOST:-mariadb}
       - SEATABLE_MYSQL_DB_PORT=${MARIADB_PORT:-3306}


### PR DESCRIPTION
This fixes a relatively common error of forgetting to create a license file.  
By default, Docker would create an empty directory on the host, which would then need to be manually removed.

Setting `create_host_path` to `false` prevents this from happening and displays an error message instead:

```
Container seatable-server Error response from daemon: invalid mount config for type bind: bind source path does not exist: $DIR/seatable-license.txt
```

Note: This is supported by Docker Engine 23.0+, which was released in February 2023.