### PR TITLE
Fix Redis signal handling

### DIFF
--- a/compose/seatable-server.yml
+++ b/compose/seatable-server.yml
@@ -156,7 +156,7 @@ services:
     command:
       - /bin/sh
       - -c
-      - redis-server --requirepass "$${REDIS_PASSWORD:?REDIS_PASSWORD variable is not set}" --maxmemory "${REDIS_MAX_MEMORY:-500mb}" --maxmemory-policy allkeys-lru
+      - exec redis-server --requirepass "$${REDIS_PASSWORD:?REDIS_PASSWORD variable is not set}" --maxmemory "${REDIS_MAX_MEMORY:-500mb}" --maxmemory-policy allkeys-lru
     networks:
       - backend-seatable-net
     healthcheck:


### PR DESCRIPTION
exec ensures that signals such as SIGTERM (sent by Docker) are properly forwarded to the Redis process. Without this, Redis will never receive the signal and will only stop itself upon receiving a SIGKILL. This change speeds up "docker compose down" and ensures a clean shutdown of the Redis instance.