### PR TITLE
Revert "ALLOWALL is not a valid value for the X-Frame-Options header"

### DIFF
--- a/compose/seatable-server.yml
+++ b/compose/seatable-server.yml
@@ -82,16 +82,22 @@ services:
         `"
       # Allow iframes for some directories
       caddy_0.route_0: /dtable/view-external-links/*
+      caddy_0.route_0.header.X-Frame-Options: "ALLOWALL"
       caddy_0.route_0.header.-Content-Security-Policy: ""
       caddy_0.route_1: /dtable/external-links/*
+      caddy_0.route_1.header.X-Frame-Options: "ALLOWALL"
       caddy_0.route_1.header.-Content-Security-Policy: ""
       caddy_0.route_2: /dtable/external-apps/*
+      caddy_0.route_2.header.X-Frame-Options: "ALLOWALL"
       caddy_0.route_2.header.-Content-Security-Policy: ""
       caddy_0.route_3: /dtable/forms/*
+      caddy_0.route_3.header.X-Frame-Options: "ALLOWALL"
       caddy_0.route_3.header.-Content-Security-Policy: ""
       caddy_0.route_4: /apps/custom/*
+      caddy_0.route_4.header.X-Frame-Options: "ALLOWALL"
       caddy_0.route_4.header.-Content-Security-Policy: ""
       caddy_0.route_5: /external-apps/*
+      caddy_0.route_5.header.X-Frame-Options: "ALLOWALL"
       caddy_0.route_5.header.-Content-Security-Policy: ""
       caddy_0.route_6: /dtable/external-apps-edit/*
       caddy_0.route_6.header.-Content-Security-Policy: ""


### PR DESCRIPTION
This reverts commit 09f1fac2be0b4e5b2106c1d8ac33108955e42263.

These overrides are required in order to allow other pages to iframe SeaTable apps/bases/forms.